### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,15 +1,15 @@
-MSynth KEYWORD1
-sample KEYWORD1
+MSynth	KEYWORD1
+sample	KEYWORD1
 
-Sine KEYWORD1
-Saw KEYWORD1
-ReverseSaw KEYWORD1
-Tri KEYWORD1
-Square KEYWORD1
+Sine	KEYWORD1
+Saw	KEYWORD1
+ReverseSaw	KEYWORD1
+Tri	KEYWORD1
+Square	KEYWORD1
 
-audioLoop KEYWORD2
-WavetableSynth KEYWORD2
-void setFreq KEYWORD2
-sample freqMod KEYWORD2
-virtual sample KEYWORD2
+audioLoop	KEYWORD2
+WavetableSynth	KEYWORD2
+void setFreq	KEYWORD2
+sample freqMod	KEYWORD2
+virtual sample	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords